### PR TITLE
v0.2.0 - Refactor: Add get_sent_requests RPC function

### DIFF
--- a/application/lockitin_app/lib/core/services/friend_service.dart
+++ b/application/lockitin_app/lib/core/services/friend_service.dart
@@ -354,6 +354,8 @@ class FriendService {
   }
 
   /// Get list of sent friend requests (outgoing pending) with recipient info
+  ///
+  /// Uses get_sent_requests RPC function for consistency with other friendship queries
   Future<List<SentRequest>> getSentRequests() async {
     try {
       final currentUserId = SupabaseClientManager.currentUserId;
@@ -363,34 +365,12 @@ class FriendService {
 
       Logger.info('Fetching sent friend requests');
 
-      // Join with users table to get recipient profile info
       final response = await SupabaseClientManager.client
-          .from('friendships')
-          .select('''
-            id,
-            friend_id,
-            created_at,
-            users!friendships_friend_id_fkey (
-              id,
-              email,
-              full_name,
-              avatar_url
-            )
-          ''')
-          .eq('user_id', currentUserId)
-          .eq('status', 'pending');
+          .rpc('get_sent_requests', params: {'user_uuid': currentUserId});
 
-      final requests = (response as List).map((json) {
-        final userData = json['users'] as Map<String, dynamic>?;
-        return SentRequest(
-          requestId: json['id'] as String,
-          recipientId: json['friend_id'] as String,
-          fullName: userData?['full_name'] as String?,
-          email: userData?['email'] as String? ?? 'Unknown',
-          avatarUrl: userData?['avatar_url'] as String?,
-          sentAt: DateTime.parse(json['created_at'] as String),
-        );
-      }).toList();
+      final requests = (response as List)
+          .map((json) => SentRequest.fromJson(json as Map<String, dynamic>))
+          .toList();
 
       Logger.info('Fetched ${requests.length} sent requests');
       return requests;

--- a/application/lockitin_app/supabase/migrations/005_get_sent_requests_rpc.sql
+++ b/application/lockitin_app/supabase/migrations/005_get_sent_requests_rpc.sql
@@ -1,0 +1,39 @@
+-- ============================================================================
+-- Migration: 005_get_sent_requests_rpc.sql
+-- Description: Add RPC function for fetching sent friend requests
+-- Issue: #99 - Add missing get_sent_requests RPC function
+-- ============================================================================
+
+-- Function to get sent (outgoing) friend requests for a user
+-- Mirrors get_pending_requests but for requests the user has sent
+CREATE OR REPLACE FUNCTION get_sent_requests(user_uuid UUID)
+RETURNS TABLE (
+  request_id UUID,
+  recipient_id UUID,
+  full_name TEXT,
+  email TEXT,
+  avatar_url TEXT,
+  sent_at TIMESTAMP WITH TIME ZONE
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    f.id as request_id,
+    f.friend_id as recipient_id,
+    u.full_name,
+    u.email,
+    u.avatar_url,
+    f.created_at as sent_at
+  FROM friendships f
+  JOIN users u ON u.id = f.friend_id
+  WHERE f.user_id = user_uuid
+    AND f.status = 'pending';
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant execute permission to authenticated users
+GRANT EXECUTE ON FUNCTION get_sent_requests(UUID) TO authenticated;
+
+-- Add comment for documentation
+COMMENT ON FUNCTION get_sent_requests IS
+'Returns all pending friend requests sent by the specified user, with recipient profile info.';

--- a/application/lockitin_app/test/core/services/friend_service_test.dart
+++ b/application/lockitin_app/test/core/services/friend_service_test.dart
@@ -302,6 +302,78 @@ void main() {
     });
   });
 
+  group('SentRequest - JSON Serialization', () {
+    test('should create SentRequest from get_sent_requests RPC result', () {
+      final json = {
+        'request_id': 'req-123',
+        'recipient_id': 'user-456',
+        'full_name': 'Jane Doe',
+        'email': 'jane@example.com',
+        'avatar_url': 'https://example.com/avatar.jpg',
+        'sent_at': '2025-12-27T10:30:00.000Z',
+      };
+
+      final request = SentRequest.fromJson(json);
+
+      expect(request.requestId, 'req-123');
+      expect(request.recipientId, 'user-456');
+      expect(request.fullName, 'Jane Doe');
+      expect(request.email, 'jane@example.com');
+      expect(request.avatarUrl, 'https://example.com/avatar.jpg');
+      expect(request.sentAt, isNotNull);
+    });
+
+    test('should handle null full_name and avatar_url', () {
+      final json = {
+        'request_id': 'req-789',
+        'recipient_id': 'user-012',
+        'full_name': null,
+        'email': 'user@example.com',
+        'avatar_url': null,
+        'sent_at': '2025-12-27T11:00:00.000Z',
+      };
+
+      final request = SentRequest.fromJson(json);
+
+      expect(request.requestId, 'req-789');
+      expect(request.fullName, isNull);
+      expect(request.email, 'user@example.com');
+      expect(request.avatarUrl, isNull);
+    });
+
+    test('displayName should prefer full name over email', () {
+      final requestWithName = SentRequest(
+        requestId: '123',
+        recipientId: '456',
+        fullName: 'John Doe',
+        email: 'john@example.com',
+        sentAt: DateTime.now(),
+      );
+
+      final requestWithoutName = SentRequest(
+        requestId: '789',
+        recipientId: '012',
+        email: 'jane@example.com',
+        sentAt: DateTime.now(),
+      );
+
+      expect(requestWithName.displayName, 'John Doe');
+      expect(requestWithoutName.displayName, 'jane@example.com');
+    });
+
+    test('initials should be calculated correctly', () {
+      final requestTwoNames = SentRequest(
+        requestId: '123',
+        recipientId: '456',
+        fullName: 'Bob Smith',
+        email: 'bob@example.com',
+        sentAt: DateTime.now(),
+      );
+
+      expect(requestTwoNames.initials, 'BS');
+    });
+  });
+
   group('FriendshipStatus Enum', () {
     test('should have all expected values', () {
       expect(FriendshipStatus.values.length, 3);


### PR DESCRIPTION
## Summary
- Add `get_sent_requests` RPC function for consistency with other friendship queries
- Update `FriendService.getSentRequests()` to use RPC instead of manual table join
- Add tests for `SentRequest.fromJson()` with RPC response format

## Problem
`FriendService.getSentRequests()` manually joined friendships + users tables instead of using a dedicated RPC function like other friendship queries.

**Before (manual join):**
```dart
final response = await supabase
    .from('friendships')
    .select('id, friend_id, created_at, users!friendships_friend_id_fkey (...)')
    .eq('user_id', currentUserId)
    .eq('status', 'pending');
```

**After (RPC):**
```dart
final response = await supabase
    .rpc('get_sent_requests', params: {'user_uuid': currentUserId});
```

## Files Changed
- `lib/core/services/friend_service.dart` - Use RPC function
- `supabase/migrations/005_get_sent_requests_rpc.sql` - New migration
- `test/core/services/friend_service_test.dart` - Add SentRequest tests

## Test Plan
- [x] Run friend_service tests - new tests pass
- [x] Apply migration to Supabase and test sent requests list

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)