### PR TITLE
v0.2.0 - Performance: Reduce notifyListeners() & optimize queries (#95, #96, #100)

### DIFF
--- a/application/lockitin_app/lib/presentation/providers/calendar_provider.dart
+++ b/application/lockitin_app/lib/presentation/providers/calendar_provider.dart
@@ -151,7 +151,7 @@ class CalendarProvider extends ChangeNotifier {
   Future<void> _loadEvents() async {
     _isLoadingEvents = true;
     _eventLoadError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       final List<EventModel> allEvents = [];

--- a/application/lockitin_app/lib/presentation/providers/friend_provider.dart
+++ b/application/lockitin_app/lib/presentation/providers/friend_provider.dart
@@ -138,7 +138,7 @@ class FriendProvider extends ChangeNotifier {
   Future<void> loadFriends() async {
     _isLoadingFriends = true;
     _friendsError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       _friends = await _friendService.getFriends();
@@ -148,7 +148,7 @@ class FriendProvider extends ChangeNotifier {
       Logger.error('Failed to load friends: $e');
     } finally {
       _isLoadingFriends = false;
-      notifyListeners();
+      notifyListeners(); // Single rebuild with final state
     }
   }
 
@@ -156,7 +156,7 @@ class FriendProvider extends ChangeNotifier {
   Future<void> loadPendingRequests() async {
     _isLoadingRequests = true;
     _requestsError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       final results = await Future.wait([
@@ -176,7 +176,7 @@ class FriendProvider extends ChangeNotifier {
       Logger.error('Failed to load pending requests: $e');
     } finally {
       _isLoadingRequests = false;
-      notifyListeners();
+      notifyListeners(); // Single rebuild with final state
     }
   }
 
@@ -202,7 +202,7 @@ class FriendProvider extends ChangeNotifier {
 
     _isSearching = true;
     _searchError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       _searchResults = await _friendService.searchUsers(query);
@@ -213,7 +213,7 @@ class FriendProvider extends ChangeNotifier {
       Logger.error('Search failed: $e');
     } finally {
       _isSearching = false;
-      notifyListeners();
+      notifyListeners(); // Single rebuild with final state
     }
   }
 
@@ -233,23 +233,22 @@ class FriendProvider extends ChangeNotifier {
   Future<bool> sendFriendRequest(String friendId) async {
     _isSendingRequest = true;
     _actionError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       await _friendService.sendFriendRequest(friendId);
       // Reload sent requests to get the complete data with recipient info
       _sentRequests = await _friendService.getSentRequests();
       Logger.info('Friend request sent to: $friendId');
-      notifyListeners();
+      _isSendingRequest = false;
+      notifyListeners(); // Single rebuild with final state
       return true;
     } catch (e) {
       _actionError = e.toString();
       Logger.error('Failed to send friend request: $e');
-      notifyListeners();
-      return false;
-    } finally {
       _isSendingRequest = false;
-      notifyListeners();
+      notifyListeners(); // Single rebuild with error state
+      return false;
     }
   }
 

--- a/application/lockitin_app/lib/presentation/providers/group_provider.dart
+++ b/application/lockitin_app/lib/presentation/providers/group_provider.dart
@@ -162,7 +162,7 @@ class GroupProvider extends ChangeNotifier {
   Future<void> loadGroups() async {
     _isLoadingGroups = true;
     _groupsError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       _groups = await _groupService.getUserGroups();
@@ -172,7 +172,7 @@ class GroupProvider extends ChangeNotifier {
       Logger.error('Failed to load groups: $e');
     } finally {
       _isLoadingGroups = false;
-      notifyListeners();
+      notifyListeners(); // Single rebuild with final state
     }
   }
 
@@ -185,7 +185,7 @@ class GroupProvider extends ChangeNotifier {
   Future<void> loadPendingInvites() async {
     _isLoadingInvites = true;
     _invitesError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       _pendingInvites = await _groupService.getPendingInvites();
@@ -195,7 +195,7 @@ class GroupProvider extends ChangeNotifier {
       Logger.error('Failed to load pending invites: $e');
     } finally {
       _isLoadingInvites = false;
-      notifyListeners();
+      notifyListeners(); // Single rebuild with final state
     }
   }
 
@@ -244,7 +244,7 @@ class GroupProvider extends ChangeNotifier {
   Future<void> loadGroupMembers(String groupId) async {
     _isLoadingMembers = true;
     _membersError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       _selectedGroupMembers = await _groupService.getGroupMembers(groupId);
@@ -254,7 +254,7 @@ class GroupProvider extends ChangeNotifier {
       Logger.error('Failed to load group members: $e');
     } finally {
       _isLoadingMembers = false;
-      notifyListeners();
+      notifyListeners(); // Single rebuild with final state
     }
   }
 
@@ -269,7 +269,7 @@ class GroupProvider extends ChangeNotifier {
   }) async {
     _isCreatingGroup = true;
     _actionError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       final group = await _groupService.createGroup(name: name, emoji: emoji);
@@ -278,16 +278,15 @@ class GroupProvider extends ChangeNotifier {
       _groups.insert(0, group);
 
       Logger.info('Created group: ${group.id}');
-      notifyListeners();
+      _isCreatingGroup = false;
+      notifyListeners(); // Single rebuild with final state
       return group;
     } catch (e) {
       _actionError = e.toString();
       Logger.error('Failed to create group: $e');
-      notifyListeners();
-      return null;
-    } finally {
       _isCreatingGroup = false;
-      notifyListeners();
+      notifyListeners(); // Single rebuild with error state
+      return null;
     }
   }
 
@@ -299,7 +298,7 @@ class GroupProvider extends ChangeNotifier {
   }) async {
     _isUpdatingGroup = true;
     _actionError = null;
-    notifyListeners();
+    // Don't notify here - reduces unnecessary rebuilds
 
     try {
       final updatedGroup = await _groupService.updateGroup(
@@ -324,16 +323,15 @@ class GroupProvider extends ChangeNotifier {
       }
 
       Logger.info('Updated group: $groupId');
-      notifyListeners();
+      _isUpdatingGroup = false;
+      notifyListeners(); // Single rebuild with final state
       return true;
     } catch (e) {
       _actionError = e.toString();
       Logger.error('Failed to update group: $e');
-      notifyListeners();
-      return false;
-    } finally {
       _isUpdatingGroup = false;
-      notifyListeners();
+      notifyListeners(); // Single rebuild with error state
+      return false;
     }
   }
 

--- a/application/lockitin_app/supabase/migrations/007_get_user_groups_with_counts.sql
+++ b/application/lockitin_app/supabase/migrations/007_get_user_groups_with_counts.sql
@@ -1,0 +1,58 @@
+-- Migration: 007_get_user_groups_with_counts
+-- Description: Create RPC function to get user groups with member counts in a single query
+-- Fixes: Issue #96 - N+1 query in getUserGroups()
+--
+-- Previously, getUserGroups() made 2 database queries:
+-- 1. Get groups via join on group_members
+-- 2. Get member counts for all groups separately
+--
+-- This RPC function combines both into a single efficient query using
+-- PostgreSQL aggregate functions.
+
+-- Drop function if exists (for idempotent migrations)
+DROP FUNCTION IF EXISTS get_user_groups_with_counts(UUID);
+
+-- Create optimized function to get user groups with member counts
+CREATE OR REPLACE FUNCTION get_user_groups_with_counts(user_uuid UUID)
+RETURNS TABLE (
+  id UUID,
+  name TEXT,
+  emoji TEXT,
+  created_by UUID,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  members_can_invite BOOLEAN,
+  member_count BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    g.id,
+    g.name::TEXT,
+    g.emoji::TEXT,
+    g.created_by,
+    g.created_at,
+    g.updated_at,
+    g.members_can_invite,
+    COUNT(gm2.user_id)::BIGINT as member_count
+  FROM group_members gm
+  INNER JOIN groups g ON g.id = gm.group_id
+  LEFT JOIN group_members gm2 ON gm2.group_id = g.id
+  WHERE gm.user_id = user_uuid
+  GROUP BY g.id, g.name, g.emoji, g.created_by, g.created_at, g.updated_at, g.members_can_invite
+  ORDER BY g.created_at DESC;
+END;
+$$;
+
+-- Grant execute permission to authenticated users
+GRANT EXECUTE ON FUNCTION get_user_groups_with_counts(UUID) TO authenticated;
+
+-- Add comment for documentation
+COMMENT ON FUNCTION get_user_groups_with_counts IS
+'Fetches all groups a user belongs to with member counts in a single query.
+Used by GroupService.getUserGroups() to avoid N+1 query pattern.
+Returns groups ordered by creation date descending.';


### PR DESCRIPTION
## Summary

- **#95**: Reduced excessive `notifyListeners()` calls in providers - now only notifies once with final state instead of twice (loading + final)
- **#96**: Fixed N+1 query in `getUserGroups()` by replacing 2 database queries with a single RPC function
- **#100**: Added memoization cache for availability calculations in GroupDetailScreen to avoid recalculating 42 times per build

## Changes

### Providers (group, friend, calendar)
- Removed intermediate `notifyListeners()` for loading states
- Single rebuild with final state reduces widget rebuilds by ~50%

### GroupService
- New RPC function `get_user_groups_with_counts` combines groups + member counts in one query
- Reduces database round-trips from 2 to 1

### GroupDetailScreen
- Added `_availabilityCache` map keyed by date
- Cache cleared when time filters, date range, or member events change

## Test plan
- [x] Verify groups list loads correctly
- [x] Verify group detail screen shows availability heatmap
- [x] Verify time filter changes update availability correctly
- [ ] Run migration `007_get_user_groups_with_counts.sql` in Supabase

## Migration Required
```sql
-- Run in Supabase SQL Editor
DROP FUNCTION IF EXISTS get_user_groups_with_counts(UUID);
-- Then run full migration from 007_get_user_groups_with_counts.sql
```

Closes #95, #96, #100

🤖 Generated with [Claude Code](https://claude.ai/code)