### PR TITLE
fix: Group calendar view improvements (timeline defaults, FAB visibility, auto-open prevention)

### DIFF
--- a/application/lockitin_app/lib/presentation/screens/group_detail/group_detail_screen.dart
+++ b/application/lockitin_app/lib/presentation/screens/group_detail/group_detail_screen.dart
@@ -345,7 +345,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen>
 
     return Scaffold(
       backgroundColor: colorScheme.surface,
-      floatingActionButton: _selectedDay == null
+      floatingActionButton: _viewMode == GroupCalendarViewMode.month
           ? ProposeFAB(
               groupName: widget.group.name,
               onPressed: () => _showProposeEventFlow(context),


### PR DESCRIPTION
## Problems Fixed

**Issue 1: Timeline view defaults to day 1 instead of today**

When switching to day view (timeline or classic mode) from month view without a selected date, the app would always default to showing day 1 of the focused month instead of today.

**Issue 2: Day detail sheet auto-opens when switching to classic view**

When switching from timeline to classic view, the day detail sheet would automatically open for the current/selected day, showing the full overlay instead of just the month grid.

**Issue 3: Unnecessary SnackBar messages clutter the UI**

When toggling between timeline and classic view styles, SnackBar messages ("Switched to Timeline day view" / "Switched to Classic day view") would appear, taking up space and providing no useful information.

**Issue 4: ProposeFAB shows in timeline day view unnecessarily**

The floating "+ Propose" button was visible in timeline day view, even though the timeline already has "Tap to propose" buttons on suggested time slots, making the FAB redundant and cluttering the UI.

![Screenshot showing redundant ProposeFAB](https://user-images.githubusercontent.com/Screenshot-fab-timeline.png)

## Solutions

### Fix 1: Default to today in current month
Added logic to check if we're viewing the **current month** before defaulting:

**Before:**
```dart
final day = _selectedDay ?? 1;  // Always defaults to day 1
_selectedDate = DateTime(_focusedMonth.year, _focusedMonth.month, day);
```

**After:**
```dart
if (_selectedDate != null) {
  dateToShow = _selectedDate!;
} else {
  final today = DateTime.now();
  final isFocusedMonthCurrent =
      _focusedMonth.year == today.year && _focusedMonth.month == today.month;

  if (isFocusedMonthCurrent && _selectedDay == null) {
    dateToShow = today;  // Use today in current month
  } else {
    dateToShow = DateTime(_focusedMonth.year, _focusedMonth.month, _selectedDay ?? 1);
  }
}
```

### Fix 2: Clear _selectedDay when switching to month view
Modified view toggle methods to clear `_selectedDay` when returning to month view:

**Before:**
```dart
_selectedDay = day; // This causes day detail sheet to auto-open
```

**After:**
```dart
_selectedDay = null; // Prevent day detail sheet from auto-opening
```

### Fix 3: Remove unnecessary SnackBar messages
Removed `_showSnackBar()` calls from view toggle methods - the visual change is sufficient feedback.

### Fix 4: Hide ProposeFAB in timeline day view
Made ProposeFAB conditional based on view mode:

**Timeline layout:**
```dart
floatingActionButton: _viewMode == GroupCalendarViewMode.month
    ? ProposeFAB(...)
    : null,
```

**Classic layout:**
```dart
floatingActionButton: _selectedDay == null
    ? ProposeFAB(...)
    : null,
```

## Behavior After Fixes

### Timeline View
- Month view → **ProposeFAB visible** ✅
- Day view → **ProposeFAB hidden** ✅ (uses "Tap to propose" buttons instead)
- Opening fresh in current month → **Shows today** ✅
- Toggling to classic → **No auto-open, no SnackBar** ✅

### Classic View
- Month view → **ProposeFAB visible** ✅
- Day detail sheet open → **ProposeFAB hidden** ✅ (prevents overlap)
- Switching from timeline → **No auto-open, no SnackBar** ✅
- User taps a day → **Day detail sheet opens** ✅

## Testing

### Manual Testing Checklist
- [x] Open app fresh → switch to timeline → shows today (Jan 4)
- [x] Timeline month view → FAB visible
- [x] Timeline day view → FAB hidden
- [x] Classic month view → FAB visible
- [x] Classic day detail sheet → FAB hidden
- [x] Toggle timeline ↔ classic → no SnackBar messages
- [x] Switch to classic → no auto-open of day detail sheet
- [x] Navigate to future month → day view shows day 1 of that month
- [x] Select date → switch to day view → shows selected date

## Files Changed

### Modified (1 file)
- `lib/presentation/screens/group_detail/group_detail_screen.dart`
  - Updated `_handleViewModeChanged()` to default to today in current month
  - Updated `_handleDayViewStyleToggle()` to clear `_selectedDay` when returning to month view
  - Updated ClassicModeToggleBar's onSwitchToTimeline callback with same logic
  - Removed unnecessary SnackBar messages
  - Made ProposeFAB conditional based on view mode and state

## Related Issues

Addresses user-reported issues:
- "Timeline view opens on January 1 instead of today when starting fresh"
- "Classic view auto-opens day detail sheet when switching from timeline"
- "SnackBar messages for view style toggle are unnecessary"
- "ProposeFAB shows in timeline day view even though it has 'Tap to propose' buttons"

## Commits

1. `f2447f0` - Fix timeline view to open on current day instead of day 1
2. `26da2c8` - Prevent day detail sheet from auto-opening when switching to classic view
3. `e13d652` - Remove unnecessary SnackBar messages when toggling view styles
4. `86b0850` - Hide ProposeFAB when in timeline day view