### PR TITLE
fix(proposals): Auto-move expired proposals to Closed tab

### DIFF
--- a/application/lockitin_app/lib/presentation/widgets/proposal_card.dart
+++ b/application/lockitin_app/lib/presentation/widgets/proposal_card.dart
@@ -109,31 +109,40 @@ class ProposalCard extends StatelessWidget {
     Color textColor;
     String label;
 
-    switch (proposal.status) {
-      case ProposalStatus.voting:
-        backgroundColor = colorScheme.primary.withValues(alpha: 0.1);
-        textColor = colorScheme.primary;
-        label = 'Active';
-        break;
-      case ProposalStatus.confirmed:
-        backgroundColor = appColors.successBackground;
-        textColor = appColors.success;
-        label = 'Confirmed';
-        break;
-      case ProposalStatus.cancelled:
-        backgroundColor = appColors.textMuted.withValues(alpha: 0.1);
-        textColor = appColors.textMuted;
-        label = 'Cancelled';
-        break;
-      case ProposalStatus.expired:
-        backgroundColor = appColors.textMuted.withValues(alpha: 0.1);
-        textColor = appColors.textMuted;
-        label = 'Expired';
-        break;
+    // Check if voting is actually open (handles expired proposals)
+    if (proposal.isVotingOpen) {
+      backgroundColor = colorScheme.primary.withValues(alpha: 0.1);
+      textColor = colorScheme.primary;
+      label = 'Active';
+    } else {
+      // Voting is closed - check why
+      switch (proposal.status) {
+        case ProposalStatus.voting:
+          // Status is voting but deadline passed = expired
+          backgroundColor = appColors.textMuted.withValues(alpha: 0.1);
+          textColor = appColors.textMuted;
+          label = 'Expired';
+          break;
+        case ProposalStatus.confirmed:
+          backgroundColor = appColors.successBackground;
+          textColor = appColors.success;
+          label = 'Confirmed';
+          break;
+        case ProposalStatus.cancelled:
+          backgroundColor = appColors.textMuted.withValues(alpha: 0.1);
+          textColor = appColors.textMuted;
+          label = 'Cancelled';
+          break;
+        case ProposalStatus.expired:
+          backgroundColor = appColors.textMuted.withValues(alpha: 0.1);
+          textColor = appColors.textMuted;
+          label = 'Expired';
+          break;
+      }
     }
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
         color: backgroundColor,
         borderRadius: BorderRadius.circular(8),


### PR DESCRIPTION
## Problem

When a proposal's voting deadline passes, the database status remains `voting` (not auto-updated to `expired`). This caused:

1. ❌ **Badge shows 'Active'** (should show 'Expired')
2. ❌ **Appears in 'Active' tab** (should be in 'Closed' tab)
3. ✅ **Deadline shows 'Closed'** (correct, but inconsistent with above)

**Root Cause:** Tab filtering and badge logic only checked database `status` field, ignoring the deadline.

**User Impact:** Confusing UX - proposal shows "Closed" but has "Active" badge in "Active" tab.

## Solution

Updated client-side logic to handle expired proposals without requiring backend changes:

### 1. Tab Filtering (`proposal_provider.dart`)

**Before:**
```dart
// Only checked status field
activeProposals => proposals.where((p) => p.status == ProposalStatus.voting)
closedProposals => proposals.where((p) => p.status \!= ProposalStatus.voting)
```

**After:**
```dart
// Checks status AND deadline
activeProposals => proposals.where((p) => p.isVotingOpen)
closedProposals => proposals.where((p) => \!p.isVotingOpen)
```

### 2. Badge Logic (`proposal_card.dart`)

**Before:**
```dart
switch (proposal.status) {
  case ProposalStatus.voting:
    label = 'Active';  // Wrong if deadline passed\!
}
```

**After:**
```dart
if (proposal.isVotingOpen) {
  label = 'Active';  // Only if truly active
} else if (proposal.status == ProposalStatus.voting) {
  label = 'Expired';  // Deadline passed but DB not updated
}
```

## Behavior

| Scenario | Status (DB) | Deadline | Tab | Badge |
|----------|-------------|----------|-----|-------|
| Voting open | voting | Future | Active | Active ✅ |
| Deadline passed | voting | Past | Closed | Expired ✅ |
| Creator confirmed | confirmed | N/A | Closed | Confirmed ✅ |
| Creator cancelled | cancelled | N/A | Closed | Cancelled ✅ |

## Testing

- ✅ Create proposal with deadline in past → appears in Closed tab with Expired badge
- ✅ Active proposal crosses deadline → auto-moves to Closed tab on refresh
- ✅ Confirmed proposals stay in Closed with Confirmed badge
- ✅ Cancelled proposals stay in Closed with Cancelled badge
- ✅ No regressions on truly active proposals

## Future Improvement

Consider adding backend cron job or trigger to auto-update `status='expired'` when deadline passes. This fix handles it gracefully on the client-side until then.

---

**Fixes:** User-reported issue (screenshot provided)
**Type:** Bug fix
**Area:** Proposals UI
**Priority:** High (UX consistency)